### PR TITLE
Update qtum, solidity & solar

### DIFF
--- a/dapp/Dockerfile
+++ b/dapp/Dockerfile
@@ -10,17 +10,17 @@ RUN wget https://github.com/mattn/goreman/releases/download/v0.0.10/goreman_linu
   unzip -o -d /usr/local/bin goreman_linux_amd64.zip && \
   rm goreman_linux_amd64.zip
 
-ENV QTUM_RELEASE 0.14.15
+ENV QTUM_RELEASE 0.15.1
 ENV QTUM_RELEASE_TAR qtum-${QTUM_RELEASE}-x86_64-linux-gnu.tar.gz
 
 RUN wget https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v${QTUM_RELEASE}/${QTUM_RELEASE_TAR} && \
   tar -xf $QTUM_RELEASE_TAR -C /usr/local --strip-components=1 --exclude=*-qt --exclude=test_qtum --exclude=qtum-tx && \
   rm $QTUM_RELEASE_TAR
 
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.19/solc-static-linux -O /usr/local/bin/solc && \
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux -O /usr/local/bin/solc && \
    chmod 0755 /usr/local/bin/solc
 
-RUN wget -v https://github.com/qtumproject/solar/releases/download/0.0.11/solar-linux-amd64 -O /usr/local/bin/solar && chmod 0755 /usr/local/bin/solar 
+RUN wget -v https://github.com/qtumproject/solar/releases/download/0.0.14/solar-linux-amd64 -O /usr/local/bin/solar && chmod 0755 /usr/local/bin/solar
 
 RUN wget https://github.com/qtumproject/qtumportal/releases/download/0.0.8/qtumportal-linux -O /usr/local/bin/qtumportal && chmod 0755 /usr/local/bin/qtumportal
 

--- a/dapp/Makefile
+++ b/dapp/Makefile
@@ -1,4 +1,4 @@
 .PHONY: image
 
 image:
-	docker build . -t hayeah/qtumportal
+	docker build . -t y0uz45/qtumportal


### PR DESCRIPTION
## Changes
* Update qtum to 0.15.1
* Update solidity to 0.4.24
* Update solar to 0.0.14

Solidity update was needed for the token contract deployment section in [Qtum Book][1] because [CappedToken.sol][2] has `pragma solidity ^0.4.23;`

[1]: https://book.qtum.org/en/part2/erc20-token.html#deploy-the-token-contract
[2]: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/746673a94f7e43835fcb5cb7b1af8ff1eea4e276/contracts/crowdsale/validation/CappedCrowdsale.sol