### PR TITLE
Latest qtumd version and solc 0.4.21

### DIFF
--- a/dapp/Dockerfile
+++ b/dapp/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/mattn/goreman/releases/download/v0.0.10/goreman_linu
   unzip -o -d /usr/local/bin goreman_linux_amd64.zip && \
   rm goreman_linux_amd64.zip
 
-ENV QTUM_RELEASE 0.16.2
+ENV QTUM_RELEASE 0.17.1
 ENV QTUM_RELEASE_TAR qtum-${QTUM_RELEASE}-x86_64-linux-gnu.tar.gz
 
 RUN wget https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v${QTUM_RELEASE}/${QTUM_RELEASE_TAR} && \

--- a/dapp/Dockerfile
+++ b/dapp/Dockerfile
@@ -10,14 +10,14 @@ RUN wget https://github.com/mattn/goreman/releases/download/v0.0.10/goreman_linu
   unzip -o -d /usr/local/bin goreman_linux_amd64.zip && \
   rm goreman_linux_amd64.zip
 
-ENV QTUM_RELEASE 0.15.2
+ENV QTUM_RELEASE 0.16.2
 ENV QTUM_RELEASE_TAR qtum-${QTUM_RELEASE}-x86_64-linux-gnu.tar.gz
 
 RUN wget https://github.com/qtumproject/qtum/releases/download/mainnet-ignition-v${QTUM_RELEASE}/${QTUM_RELEASE_TAR} && \
   tar -xf $QTUM_RELEASE_TAR -C /usr/local --strip-components=1 --exclude=*-qt --exclude=test_qtum --exclude=qtum-tx && \
   rm $QTUM_RELEASE_TAR
 
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.24/solc-static-linux -O /usr/local/bin/solc && \
+RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.21/solc-static-linux -O /usr/local/bin/solc && \
    chmod 0755 /usr/local/bin/solc
 
 RUN wget -v https://github.com/qtumproject/solar/releases/download/0.0.14/solar-linux-amd64 -O /usr/local/bin/solar && chmod 0755 /usr/local/bin/solar 


### PR DESCRIPTION
1) Using latest qtum version.

2) Proposing to use solc 0.4.21 until bug [548](https://github.com/qtumproject/qtum/issues/548) There is no option to use --homestead option hence solc 0.4.24 has problem calling a contract from another contract.