### PR TITLE
added new simpleABI into the fold

### DIFF
--- a/proto-x86/Dockerfile
+++ b/proto-x86/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu
-MAINTAINER earlz
+LABEL maintainers "earlz, VoR0220"
 
 WORKDIR /root
 RUN set -emx \
     && apt-get update \
-    && apt-get install -y -qq --no-install-recommends ca-certificates curl wget apt-utils build-essential git libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils git cmake libboost-all-dev software-properties-common texinfo bison flex libmpc-dev libmpfr-dev libgmp3-dev yasm \
+    && apt-get install -y -qq --no-install-recommends ca-certificates curl wget apt-utils build-essential git libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils git cmake libboost-all-dev software-properties-common texinfo bison flex libmpc-dev libmpfr-dev libgmp3-dev yasm golang-go\
     && add-apt-repository ppa:bitcoin/bitcoin -y \
     && apt-get update \
     && apt-get install libdb4.8-dev libdb4.8++-dev -y -qq --no-install-recommends
@@ -27,7 +27,7 @@ RUN set -ex \
 ENV PREFIX=/opt/cross
 ENV TARGET=i686-elf
 ENV SYSROOT=/opt/x86-compiler/sysroot
-ENV PATH=${PATH}:${SYSROOT}/bin:$PREFIX/bin:/root/qtum:/root/qtum:/root/qtum-docker/proto-x86/utils
+ENV PATH=${PATH}:${SYSROOT}/bin:$PREFIX/bin:/root/qtum:/root/qtum:/root/qtum-docker/proto-x86/utils:/root/go/bin
 
 # build the freestanding compiler
 RUN set -ex \
@@ -122,6 +122,9 @@ RUN set -ex \
     && cd libqtum \
     && make \
     && make deploy
+
+# get simpleabi (this url should change in the future)
+RUN go get -u github.com/qtumproject/SimpleABI && go install github.com/qtumproject/SimpleABI
 
 # get docker helpers
 RUN set -ex \

--- a/proto-x86/helpers.sh
+++ b/proto-x86/helpers.sh
@@ -26,3 +26,8 @@ function qx86make() {
 }
 export -f qx86make
 
+function qx86simpleabi() {
+    docker run -it -v "${PWD}:/root/bind" -w /root/bind qtumx86 SimpleABI -a "$1" -d -e
+}
+
+export -f qx86simpleabi


### PR DESCRIPTION
# Description
Added support for SimpleABI in the docker container

# Testing instructions
Follow same setup instructions as per https://x86.qtum.org/intro/toolchain.html. Beyond that, go into a directory containing a `.abi` file (see https://github.com/qtumproject/SimpleABI for details) and, after sourcing the bash file, run qx86simpleabi myFileHere.abi and the abi files should be generated here. Note to user: do not put absolute path imports in your abi file while using the docker container as there are some conflicts between the native machine and the docker container. Unsure how to fix this. 

# Types of changes
New feature (non-breaking change which adds functionality)

# Checklist
- [ ] Update documentation as needed (might be required here? Not sure).
Signed-off-by: VoR0220 <catalanor0220@gmail.com>