### PR TITLE
Update dockerfile to support multiarch

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -7,7 +7,7 @@ RUN set -ex \
 
 # install qtum binaries
 RUN set -ex \
-    && echo `curl -s https://api.github.com/repos/qtumproject/qtum/releases/latest | jq -r ".assets[] | select(.name | test(\"x86_64-linux-gnu.tar.gz\")) | .browser_download_url"` > /tmp/qtum_url \
+    && echo `curl -s https://api.github.com/repos/qtumproject/qtum/releases/latest | jq -r ".assets[] | select(.name | test(\"$(uname -p | sed s/ppc/powerpc/ | sed s/armv7l/arm/).*-linux.*.tar.gz\")) | .browser_download_url"` > /tmp/qtum_url \
     && QTUM_URL=`cat /tmp/qtum_url` \
     && QTUM_DIST=$(basename $QTUM_URL) \
     && wget -O $QTUM_DIST $QTUM_URL \

--- a/release/README.md
+++ b/release/README.md
@@ -16,6 +16,11 @@ $ docker pull qtum/qtum
 $docker build --rm -t qtum/qtum .
 ```
 
+### Or, build a multi-arch container image
+```
+docker buildx build --platform linux/arm64,linux/amd64,linux/riscv64,linux/ppc64le,linux/arm/v7 -t qtum/qtum .
+```
+
 For historical versions, please visit [docker hub](https://hub.docker.com/r/qtum/qtum/)
 
 ## Prepare data path and qtum.conf


### PR DESCRIPTION
This updates the Dockerfile to use the compiling architecture `uname -p` to fetch the released qtum image from github.

You can then use `docker buildx build` to do multi architecture builds